### PR TITLE
Refactor Get-PasskeyDeviceBoundAAGUID function to fix Windows PowerShell issue

### DIFF
--- a/src/EntraIDPasskeyHelper.psd1
+++ b/src/EntraIDPasskeyHelper.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'EntraIDPasskeyHelper.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.2'
+    ModuleVersion     = '1.0.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
This pull request includes two commits. The first commit refactors the Get-PasskeyDeviceBoundAAGUID function to handle different PowerShell editions. The second commit bumps the module version to 1.0.3.

The changes in the code include updating the ModuleVersion property in the module manifest file and modifying the Get-PasskeyDeviceBoundAAGUID function to handle different PowerShell editions. The function now checks the PSEdition and uses different approaches to select the id property from the returned values based on the PowerShell edition.

These changes improve the compatibility and functionality of the module.